### PR TITLE
feat: add observer pattern example code (golang)

### DIFF
--- a/Observer/go/go.mod
+++ b/Observer/go/go.mod
@@ -1,0 +1,3 @@
+module observer
+
+go 1.18

--- a/Observer/go/main.go
+++ b/Observer/go/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"observer/observable"
+	"observer/observer"
+)
+
+func main() {
+	// Init subject (observable instance)
+	weatherData := observable.NewWeatherData()
+
+	// Init observers
+	currentDisplay := observer.NewCurrentConditionsDisplay()
+	statisticsDisplay := observer.NewStatisticsDisplay()
+	forecastDisplay := observer.NewForecastDisplay()
+	heatIndexDisplay := observer.NewHeatIndexDisplay()
+
+	// Register observers at subject
+	weatherData.RegisterObserver(currentDisplay)
+	weatherData.RegisterObserver(statisticsDisplay)
+	weatherData.RegisterObserver(forecastDisplay)
+	weatherData.RegisterObserver(heatIndexDisplay)
+
+	// Update value of subject
+	fmt.Println("\nMeasurements #1")
+	weatherData.SetMeasurements(80, 65, 30.4)
+
+	// Update value of subject
+	fmt.Println("\nMeasurements #2")
+	weatherData.RemoveObserver(forecastDisplay)
+	weatherData.SetMeasurements(82, 70, 29.2)
+
+	// Update value of subject
+	fmt.Println("\nMeasurements #3")
+	weatherData.SetMeasurements(78, 90, 29.2)
+}

--- a/Observer/go/observable/observable.go
+++ b/Observer/go/observable/observable.go
@@ -1,0 +1,9 @@
+package observable
+
+import "observer/observer"
+
+type Observable interface {
+	RegisterObserver(observer observer.Observer)
+	RemoveObserver(observer observer.Observer)
+	NotifyAll()
+}

--- a/Observer/go/observable/weather_data.go
+++ b/Observer/go/observable/weather_data.go
@@ -1,0 +1,61 @@
+package observable
+
+import "observer/observer"
+
+type WeatherData struct {
+	Observers   []observer.Observer
+	Temperature float64
+	Humidity    float64
+	Pressure    float64
+}
+
+func NewWeatherData() *WeatherData {
+	return &WeatherData{
+		Observers: []observer.Observer{},
+	}
+}
+
+func (d *WeatherData) RegisterObserver(observer observer.Observer) {
+	d.Observers = append(d.Observers, observer)
+}
+
+func (d *WeatherData) RemoveObserver(observer observer.Observer) {
+	for k, v := range d.Observers {
+		if v == observer {
+			d.Observers = remove(d.Observers, k)
+		}
+	}
+}
+
+func (d *WeatherData) NotifyAll() {
+	for _, o := range d.Observers {
+		o.Update(d.Temperature, d.Humidity, d.Pressure)
+	}
+}
+
+func (d *WeatherData) MeasurementsChanged() {
+	d.NotifyAll()
+}
+
+func (d *WeatherData) SetMeasurements(temp, humidity, pressure float64) {
+	d.Temperature = temp
+	d.Humidity = humidity
+	d.Pressure = pressure
+	d.MeasurementsChanged()
+}
+
+func (d *WeatherData) GetTemperature() float64 {
+	return d.Temperature
+}
+
+func (d *WeatherData) GetHumidity() float64 {
+	return d.Humidity
+}
+
+func (d *WeatherData) GetPressure() float64 {
+	return d.Pressure
+}
+
+func remove(slice []observer.Observer, index int) []observer.Observer {
+	return append(slice[:index], slice[index+1:]...)
+}

--- a/Observer/go/observer/conditions_display.go
+++ b/Observer/go/observer/conditions_display.go
@@ -1,0 +1,27 @@
+package observer
+
+import (
+	"fmt"
+)
+
+type CurrentConditionsDisplay struct {
+	Temperature float64
+	Humidity    float64
+}
+
+func NewCurrentConditionsDisplay() *CurrentConditionsDisplay {
+	display := &CurrentConditionsDisplay{}
+	return display
+}
+
+func (d *CurrentConditionsDisplay) Update(temp, humidity, pressure float64) {
+	d.Temperature = temp
+	d.Humidity = humidity
+	d.Display()
+}
+
+func (d *CurrentConditionsDisplay) Display() {
+	fmt.Println("[Current conditions]")
+	fmt.Println(fmt.Sprintf("Temperature: %v", d.Temperature))
+	fmt.Println(fmt.Sprintf("Humidity: %v", d.Humidity))
+}

--- a/Observer/go/observer/forecast_display.go
+++ b/Observer/go/observer/forecast_display.go
@@ -1,0 +1,32 @@
+package observer
+
+import (
+	"fmt"
+)
+
+type ForecastDisplay struct {
+	CurrentPressure float64
+	LastPressure    float64
+}
+
+func NewForecastDisplay() *ForecastDisplay {
+	display := &ForecastDisplay{}
+	return display
+}
+
+func (d *ForecastDisplay) Update(temp, humidity, pressure float64) {
+	d.LastPressure = d.CurrentPressure
+	d.CurrentPressure = pressure
+	d.Display()
+}
+
+func (d *ForecastDisplay) Display() {
+	fmt.Println("[Forecast]")
+	if d.CurrentPressure > d.LastPressure {
+		fmt.Println("Improving weather on the way!")
+	} else if d.CurrentPressure == d.LastPressure {
+		fmt.Println("More of the same")
+	} else {
+		fmt.Println("Watch out for cooler, rainy weather")
+	}
+}

--- a/Observer/go/observer/heat_index_display.go
+++ b/Observer/go/observer/heat_index_display.go
@@ -1,0 +1,28 @@
+package observer
+
+import (
+	"fmt"
+)
+
+type HeatIndexDisplay struct {
+	HeatIndex float64
+}
+
+func NewHeatIndexDisplay() *HeatIndexDisplay {
+	display := &HeatIndexDisplay{}
+	return display
+}
+
+func (d *HeatIndexDisplay) Update(temp, humidity, pressure float64) {
+	d.HeatIndex = computeHeatIndex(temp, humidity)
+	d.Display()
+}
+
+func (d *HeatIndexDisplay) Display() {
+	fmt.Println("[Heat index display]")
+	fmt.Println(fmt.Sprintf("Heat index: %v", d.HeatIndex))
+}
+
+func computeHeatIndex(t, rh float64) float64 {
+	return (16.923 + (0.185212 * t) + (5.37941 * rh) - (0.100254 * t * rh) + (0.00941695 * (t * t)) + (0.00728898 * (rh * rh)) + (0.000345372 * (t * t * rh)) - (0.000814971 * (t * rh * rh)) + (0.0000102102 * (t * t * rh * rh)) - (0.000038646 * (t * t * t)) + (0.0000291583 * (rh * rh * rh)) + (0.00000142721 * (t * t * t * rh)) + (0.000000197483 * (t * rh * rh * rh)) - (0.0000000218429 * (t * t * t * rh * rh)) + 0.000000000843296*(t*t*rh*rh*rh)) - (0.0000000000481975 * (t * t * t * rh * rh * rh))
+}

--- a/Observer/go/observer/observer.go
+++ b/Observer/go/observer/observer.go
@@ -1,0 +1,5 @@
+package observer
+
+type Observer interface {
+	Update(temp float64, humidity float64, pressure float64)
+}

--- a/Observer/go/observer/statistics_display.go
+++ b/Observer/go/observer/statistics_display.go
@@ -1,0 +1,39 @@
+package observer
+
+import (
+	"fmt"
+)
+
+type StatisticsDisplay struct {
+	MaxTemperature float64
+	MinTemperature float64
+	TemperatureSum float64
+	NumReadings    int
+}
+
+func NewStatisticsDisplay() *StatisticsDisplay {
+	display := &StatisticsDisplay{}
+	display.MinTemperature = 200
+	return display
+}
+
+func (d *StatisticsDisplay) Update(temp, humidity, pressure float64) {
+	d.TemperatureSum += temp
+	d.NumReadings++
+
+	if temp > d.MaxTemperature {
+		d.MaxTemperature = temp
+	}
+	if temp < d.MinTemperature {
+		d.MinTemperature = temp
+	}
+
+	d.Display()
+}
+
+func (d *StatisticsDisplay) Display() {
+	fmt.Println("[Statistics]")
+	fmt.Println(fmt.Sprintf("Avg: %v", d.TemperatureSum/float64(d.NumReadings)))
+	fmt.Println(fmt.Sprintf("Max: %v", d.MaxTemperature))
+	fmt.Println(fmt.Sprintf("Min: %v", d.MinTemperature))
+}

--- a/README.md
+++ b/README.md
@@ -51,4 +51,5 @@
 <br>
 
 ## 🧷 Reference
+- 예제 소스 코드: https://github.com/belhyun/belhyun_hf_dp
 - 디자인 패턴 분류: https://github.com/Effective-Java-Camp/head-first-design-pattern/wiki


### PR DESCRIPTION
## 요약
- golang으로 작성된 옵저버 패턴 예제 코드

## Dear reviewers
@qkrqudcks7 
- strategy는 내가 작성한 거랑 거의 똑같아서 따로 리뷰나 추가할 필요 없을 것 같음~!
- observer는 예제 코드 없어서 추가해봤는데 피드백 줄 거 있으면 코멘트 기기~
- 아마 자바 예제랑 다른 부분은 `observer`를 생성할 때 `observable` 인터페이스를 파라미터로 주지 않는 정도?
    - observer들을 `observer` 패키지로 관리하고 싶은데 observer 생성 시에 `observable` 인터페이스를 파라미터로 주면 `observer `패키지에 `observable` 패키지가 import
    - 이 경우에 클라이언트(main 함수) 실행 시 `observer` -> `observable` -> `observer` 를 참조하면서 import cycle 현상 발생
    - 이를 방지하기 위해서 클라이언트에서 register를 해주는 방식으로 수정

@kmswlee 
- observer 패턴에 go 예제 코드 추가한거라서 그냥 참고만 하시면 될 것 같습니다~
- 자바 코드는 잘 봤습니다. 고생하셨습니당~!